### PR TITLE
Revert "Adds babel to dev dependencies"

### DIFF
--- a/src/client/package-lock.json
+++ b/src/client/package-lock.json
@@ -103,12 +103,6 @@
       "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
       "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0="
     },
-    "babel": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel/-/babel-6.23.0.tgz",
-      "integrity": "sha1-0NHn2APpdHZb7qMjLU4VPA77kPQ=",
-      "dev": true
-    },
     "babel-cli": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-cli/-/babel-cli-6.26.0.tgz",

--- a/src/client/package.json
+++ b/src/client/package.json
@@ -40,7 +40,6 @@
   },
   "homepage": "https://github.com/DianaVashti/react-webpack-materialui-boilerplate#readme",
   "devDependencies": {
-    "babel": "^6.23.0",
     "babel-cli": "^6.24.0",
     "babel-core": "~6.20.0",
     "babel-loader": "~6.2.9",
@@ -49,9 +48,9 @@
     "babel-plugin-transform-regenerator": "^6.22.0",
     "babel-plugin-transform-runtime": "^6.23.0",
     "babel-polyfill": "^6.23.0",
-    "babel-preset-env": "^1.6.1",
     "babel-preset-react": "~6.16.0",
-    "babel-runtime": "~6.20.0"
+    "babel-runtime": "~6.20.0",
+    "babel-preset-env": "^1.6.1"
   },
   "proxy": "http://localhost:3030/"
 }


### PR DESCRIPTION
Reverts JC-JAM/polonaise#5

"The babel package is no more. Previously, it was the entire compiler and all the transforms plus a bunch of CLI tools, but this lead to unnecessarily large downloads and was a bit confusing. Now we’ve split it up into two separate packages: babel-cli and babel-core."